### PR TITLE
Fixes for external vdt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(VecMath INTERFACE VecCore::VecCore)
 find_package(Vdt)
 if(VDT_FOUND)
   include_directories(${VDT_INCLUDE_DIR})
+  set(VecMath_EXTERNAL_INCLUDES "${VECGEOM_EXTERNAL_INCLUDES};${VDT_INCLUDE_DIR}")
 else()
 
   #GetVDT on cmake generation phase to prevent rebuilding when using this lib from inside your project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,8 @@ ExternalProject_Add(vdt
 
         INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/builtin_vdt/install
         INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/builtin_vdt/include/VecMath/Private/vdt
-        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_BINARY_DIR}/builtin_vdt/install/include/vdt ${CMAKE_CURRENT_BINARY_DIR}/builtin_vdt/include/VecMath/Private/vdt
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/builtin_vdt/include/vdt
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_BINARY_DIR}/builtin_vdt/install/include/vdt ${CMAKE_CURRENT_BINARY_DIR}/builtin_vdt/include/vdt
 	)
   "
   )
@@ -57,8 +57,8 @@ ExternalProject_Add(vdt
   target_include_directories(VecMath INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/builtin_vdt/include>)
 
   #installation configuration
-  #Install vdt headers(without shared lib) to $INSTALL_DESTINATION/include/VecMath/Private/vdt/*.h when VecMath is installed
-  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/builtin_vdt/include/VecMath/Private DESTINATION include/VecMath FILES_MATCHING PATTERN "*.h")
+  #Install vdt headers(without shared lib) to $INSTALL_DESTINATION/include/vdt/*.h when VecMath is installed
+  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/builtin_vdt/include/ DESTINATION include FILES_MATCHING PATTERN "*.h")
 
 endif()
 

--- a/cmake/VecMathConfig.cmake.in
+++ b/cmake/VecMathConfig.cmake.in
@@ -20,7 +20,8 @@ include(${CMAKE_CURRENT_LIST_DIR}/VecMathTargets.cmake)
 
 #for old cmake support
 if(VecMath_FOUND)
-  set(VecMath_INCLUDE_DIRS ${VecMath_INCLUDE_DIR} ${VecCore_INCLUDE_DIRS})
+  set(VecMath_EXTERNAL_INCLUDES "@VecMath_EXTERNAL_INCLUDES@")
+  set(VecMath_INCLUDE_DIRS ${VecMath_EXTERNAL_INCLUDES} ${VecMath_INCLUDE_DIR} ${VecCore_INCLUDE_DIRS})
   set(VecMath_DEFINITIONS ${VecCore_DEFINITIONS})
   set(VecMath_LIBRARIES ${VecCore_LIBRARIES})
 endif()

--- a/include/VecMath/Math/FastExp.h
+++ b/include/VecMath/Math/FastExp.h
@@ -1,7 +1,7 @@
 #ifndef VECMATH_MATH_FASTEXP_H
 #define VECMATH_MATH_FASTEXP_H
 
-#include "VecMath/Private/vdt/exp.h"
+#include "vdt/exp.h"
 #include <VecCore/VecCore>
 
 namespace vecMath {

--- a/include/VecMath/Math/FastLog.h
+++ b/include/VecMath/Math/FastLog.h
@@ -1,7 +1,7 @@
 #ifndef VECMATH_MATH_FASTLOG_H
 #define VECMATH_MATH_FASTLOG_H
 
-#include "VecMath/Private/vdt/log.h"
+#include "vdt/log.h"
 #include <VecCore/VecCore>
 
 namespace vecMath {

--- a/include/VecMath/Math/FastSinCos.h
+++ b/include/VecMath/Math/FastSinCos.h
@@ -1,7 +1,7 @@
 #ifndef VECMATH_MATH_FASTSINCOS_H
 #define VECMATH_MATH_FASTSINCOS_H
 
-#include "VecMath/Private/vdt/sincos.h"
+#include "vdt/sincos.h"
 #include <VecCore/VecCore>
 
 namespace vecMath {


### PR DESCRIPTION
Followup to #2:
* the modified path was causing problems. VecCore doesn't use such a modified include path for its builtins (Vc and umesimd), so I don't think it's necessary here. (Let me know if I'm wrong...)
* had to update the cmake config file with the external vdt path