### PR TITLE
Fix forward declaration, from class to struct keyword

### DIFF
--- a/include/VecMath/Rng/VecRNG.h
+++ b/include/VecMath/Rng/VecRNG.h
@@ -14,7 +14,7 @@
 namespace vecRng {
 inline namespace VECRNG_IMPL_NAMESPACE {
 
-template <typename DerivedT> class RNG_traits;
+template <typename DerivedT> struct RNG_traits;
 
 template <typename DerivedT> class VecRNG {
 


### PR DESCRIPTION
Fixes warnings on the compilation of client code (GeantV).