### PR TITLE
Copied Timer.h from VecCore, so it doesn't depend on VecCore for it.

### DIFF
--- a/test/RngTest/inc/Timer.h
+++ b/test/RngTest/inc/Timer.h
@@ -1,0 +1,59 @@
+#ifndef VECCORE_TIMER_H
+#define VECCORE_TIMER_H
+
+#include <chrono>
+
+using namespace std::chrono;
+
+template <class unit = nanoseconds>
+class Timer {
+  using clock = high_resolution_clock;
+
+public:
+  Timer() : fStart(), fStop() { Start(); }
+
+  void Reset() { Start(); }
+
+  void Start() { fStart = clock::now(); }
+
+  double Elapsed()
+  {
+    fStop = clock::now();
+    return duration_cast<unit>(fStop - fStart).count();
+  }
+
+private:
+  high_resolution_clock::time_point fStart, fStop;
+};
+
+#if !defined(VECCORE_CUDA_DEVICE_COMPILATION)
+
+class cycles {
+};
+
+template <>
+class Timer<cycles> {
+public:
+  Timer() { Start(); }
+
+  void Reset() { Start(); }
+
+  void Start() { fStart = GetCycleCount(); }
+
+  double Elapsed() { return static_cast<double>(GetCycleCount() - fStart); }
+
+private:
+  unsigned long long int fStart;
+
+  inline __attribute__((always_inline)) unsigned long long int GetCycleCount()
+  {
+    unsigned int hi, lo;
+    asm volatile("cpuid\n\t"
+                 "rdtsc"
+                 : "=a"(lo), "=d"(hi));
+    return ((unsigned long long)lo) | (((unsigned long long)hi) << 32);
+  }
+};
+#endif
+
+#endif

--- a/test/RngTest/src/PdfBenchmarker.cc
+++ b/test/RngTest/src/PdfBenchmarker.cc
@@ -1,7 +1,7 @@
 #include "PdfBenchmarker.h"
 #include "PdfBenchmarker_cpu.h"
 
-#include "VecCore/Timer.h"
+#include "Timer.h"
 
 namespace vecrng {
 

--- a/test/RngTest/src/PdfBenchmarker_cpu.cc
+++ b/test/RngTest/src/PdfBenchmarker_cpu.cc
@@ -1,4 +1,4 @@
-#include "VecCore/Timer.h"
+#include "Timer.h"
 
 #include "VecMath/Rng/MRG32k3a.h"
 

--- a/test/RngTest/src/RngBenchmarker.cc
+++ b/test/RngTest/src/RngBenchmarker.cc
@@ -1,7 +1,7 @@
 #include "RngBenchmarker.h"
 #include "RngBenchmarker_cpu.h"
 
-#include "VecCore/Timer.h"
+#include "Timer.h"
 
 namespace vecrng {
 

--- a/test/RngTest/src/RngBenchmarker_cpu.cc
+++ b/test/RngTest/src/RngBenchmarker_cpu.cc
@@ -1,4 +1,4 @@
-#include "VecCore/Timer.h"
+#include "Timer.h"
 
 #include "VecMath/Rng/MRG32k3a.h"
 #include "VecMath/Rng/Philox.h"


### PR DESCRIPTION
After tag 0.5.2, VecCore has renamed VecCore/Timer.h to VecCore/timer.h, and this file is not being installed anymore, which VecMath depends on.

So I copied VecCore/Timer.h into test/RngTest/inc/ directory, and adapted the old #include's accordingly.
